### PR TITLE
Improve Compatibility with the Arduino IDE

### DIFF
--- a/examples/packetio_streaming/packetio_streaming.ino
+++ b/examples/packetio_streaming/packetio_streaming.ino
@@ -8,7 +8,7 @@ COBSPrint cobs_out(Serial);
 COBSStream cobs_in(Serial);
 
 void setup() {
-    Serial.begin();
+    Serial.begin(9600);
 }
 
 void loop() {

--- a/examples/packetio_streaming/packetio_streaming.ino
+++ b/examples/packetio_streaming/packetio_streaming.ino
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <packet_interfaces.h>
 #include <cobs/Stream.h>
 #include <cobs/Print.h>
 using namespace packetio;

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=PacketIO
+version=0.3.0
+author=Eric Wieser
+maintainer=Eric Wieser
+sentence=Packetizing wrapper for arduino Streams.
+paragraph=For framing packets sent or received over an arduino Stream, such as Serial.
+category=Communication
+url=https://github.com/eric-wieser/packet-io
+architectures=*
+includes=packet_interfaces.h


### PR DESCRIPTION
- Add library.properties metadata file to allow the Arduino IDE to recognize the library.
- Make example sketch compatible with the Arduino IDE.
- Fix error in example sketch.