### PR TITLE
Make Print a public base class of Stream in compat headers

### DIFF
--- a/src/_compat/Stream.h
+++ b/src/_compat/Stream.h
@@ -16,7 +16,7 @@
    *             <a href="https://www.arduino.cc/en/Reference/Stream">Stream</a>
    *             class, for use on other platforms
    */
-  class Stream : Print
+  class Stream : public Print
   {
     protected:
       unsigned long _timeout;      // number of milliseconds to wait for the next char before aborting timed read


### PR DESCRIPTION
This matches the real Arduino API and allows a Stream to be passed to COBSPrint.