### PR TITLE
Fix COBSPrint::abort() and add PacketPrint::reset()

### DIFF
--- a/src/cobs/Print.h
+++ b/src/cobs/Print.h
@@ -126,8 +126,6 @@ public:
     }
 
     virtual void abort() override {
-        _counter = 0;
-
         // mid-chunk - sending a 0 is illegal
         if(_written_upto != SIZE_MAX) {
             _base.write((uint8_t) 0);
@@ -138,6 +136,11 @@ public:
             _base.write((uint8_t) 2);
             _base.write((uint8_t) 0);
         }
+
+        // reset leftover buffer
+        _written_upto = SIZE_MAX;
+        // begin the next packet
+        _counter = 1;
     }
 };
 

--- a/src/cobs/Print.h
+++ b/src/cobs/Print.h
@@ -137,6 +137,10 @@ public:
             _base.write((uint8_t) 0);
         }
 
+        reset();
+    }
+
+    virtual void reset() override {
         // reset leftover buffer
         _written_upto = SIZE_MAX;
         // begin the next packet

--- a/src/escaped/Print.h
+++ b/src/escaped/Print.h
@@ -103,6 +103,10 @@ public:
             // we already sent ESC
             _base.write((uint8_t) EscapeCodes::END);
         }
+        reset();
+    }
+
+    virtual void reset() override {
         _pending_escape = -1;
     }
 };

--- a/src/packet_interfaces.h
+++ b/src/packet_interfaces.h
@@ -29,6 +29,12 @@ public:
     virtual void abort() = 0;
 
     /*!
+        @brief Reset any internal state to allow a new packet to be started
+        without ending the current packet.
+    */
+    virtual void reset() = 0;
+
+    /*!
         @overload virtual size_t write(uint8_t val)
         @brief  Write a single byte to the current packet.
         @param  val the byte to encode

--- a/test/test_cobs_encode.cpp
+++ b/test/test_cobs_encode.cpp
@@ -122,6 +122,18 @@ static void test_cobs_long() {
 
 }
 
+static void test_cobs_abort(void) {
+    MockPrint mp(short_buf);
+    COBSPrint p(mp);
+
+    TEST_ASSERT_EQUAL(4, p.write("1234"));
+    p.abort();
+    TEST_ASSERT_EQUAL(4, p.write("5678"));
+    TEST_ASSERT(p.end());
+
+    TEST_ASSERT_EQUAL_STREAM("\x02\x00\x05""5678\x00", mp);
+}
+
 void run_all_cobs_encode() {
     RUN_TEST(test_cobs_basic);
     RUN_TEST(test_cobs_basic0);
@@ -131,6 +143,7 @@ void run_all_cobs_encode() {
     RUN_TEST(test_cobs_interrupted0);
     RUN_TEST(test_cobs_interrupted_many);
     RUN_TEST(test_cobs_long);
+    RUN_TEST(test_cobs_abort);
 }
 
 #endif


### PR DESCRIPTION
`COBSPrint::abort()` has two bugs: the leftover buffer is not reset, causing old data to be printed after the abort, and the counter is reset to 0 instead of 1, causing the next packet to fail.

For my application, I need the ability to reset the internal packet state without trying to terminate the current packet, so I added the `PacketPrint::reset()` method.

These changes build off each other, so I put them in the same PR.